### PR TITLE
Fix crunching of unnamed routes

### DIFF
--- a/src/Jobs/CrunchStatistics.php
+++ b/src/Jobs/CrunchStatistics.php
@@ -51,7 +51,7 @@ class CrunchStatistics implements ShouldQueue
                 });
 
                 $route = app('rinvex.statistics.route')->firstOrCreate([
-                    'name' => $laravelRoute->getName(),
+                    'name' => $laravelRoute->getName() ?: $laravelRoute->uri(),
                 ], [
                     'path' => $laravelRoute->uri(),
                     'action' => $laravelRoute->getActionName(),


### PR DESCRIPTION
Some of my (API) routes haven't got a route name. When crunching the requests an error occurred because in the `statistics_routes` table `name` is `NOT NULL`.